### PR TITLE
fix Ut8Formatter when formatting floating-point whole number

### DIFF
--- a/Hexa.NET.Utilities.Tests/Utf8FormatterTests.cs
+++ b/Hexa.NET.Utilities.Tests/Utf8FormatterTests.cs
@@ -49,4 +49,52 @@ public class Utf8FormatterTests
         // Assert
         Assert.That(Encoding.UTF8.GetString(utf8Span), Is.EqualTo(expected));
     }
+
+    [TestCase(10, 0, ".","10")]
+    [TestCase(10, 0, "\uFF0C","10")]
+    [TestCase(0.75f, 2, ".","0.75")]
+    [TestCase(0.75f, 2, "\uFF0C","0\uFF0C75")]
+    public unsafe void FormatFloatCultureTest(float value, int digit, string separator, string expected)
+    {
+        // Arrange
+        byte* buffer = stackalloc byte[128];
+        var culture = new CultureInfo( "", false )
+        {
+            NumberFormat =
+            {
+                CurrencyDecimalSeparator = separator
+            }
+        };
+
+        // Act
+        int len = Utf8Formatter.Format(value, buffer, 128, culture, digit);
+        ReadOnlySpan<byte> utf8Span = new ReadOnlySpan<byte>(buffer, len);
+
+        // Assert
+        Assert.That(Encoding.UTF8.GetString(utf8Span), Is.EqualTo(expected));
+    }
+
+    [TestCase(10, 0, ".","10")]
+    [TestCase(10, 0, "\uFF0C","10")]
+    [TestCase(0.75, 2, ".","0.75")]
+    [TestCase(0.75, 2, "\uFF0C","0\uFF0C75")]
+    public unsafe void FormatDoubleCultureTest(double value, int digit, string separator, string expected)
+    {
+        // Arrange
+        byte* buffer = stackalloc byte[128];
+        var culture = new CultureInfo( "", false )
+        {
+            NumberFormat =
+            {
+                CurrencyDecimalSeparator = separator
+            }
+        };
+
+        // Act
+        int len = Utf8Formatter.Format(value, buffer, 128, culture, digit);
+        var utf8Span = new ReadOnlySpan<byte>(buffer, len);
+
+        // Assert
+        Assert.That(Encoding.UTF8.GetString(utf8Span), Is.EqualTo(expected));
+    }
 }

--- a/Hexa.NET.Utilities.Tests/Utf8FormatterTests.cs
+++ b/Hexa.NET.Utilities.Tests/Utf8FormatterTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Globalization;
+using System.Text;
+using Hexa.NET.Utilities.Text;
+
+namespace Hexa.NET.Utilities.Tests;
+
+public class Utf8FormatterTests
+{
+    [TestCase(1f, 0, "1")]
+    [TestCase(10f, 0, "10")]
+    [TestCase(0.5f, 1, "0.5")]
+    [TestCase(0.75f, 2, "0.75")]
+    [TestCase(0.125f, 3, "0.125")]
+    [TestCase(0.0625f, 4, "0.0625")]
+    [TestCase(0.03125f, 5, "0.03125")]
+    [TestCase(0.015625f, 6, "0.015625")]
+    [TestCase(0.0078125f, 7, "0.0078125")]
+    public unsafe void FormatFloatTest(float value, int digit, string expected)
+    {
+        // Arrange
+        byte* buffer = stackalloc byte[128];
+
+        // Act
+        int len = Utf8Formatter.Format(value, buffer, 128, CultureInfo.InvariantCulture, digit);
+        ReadOnlySpan<byte> utf8Span = new ReadOnlySpan<byte>(buffer, len);
+
+        // Assert
+        Assert.That(Encoding.UTF8.GetString(utf8Span), Is.EqualTo(expected));
+    }
+
+    [TestCase(1, 0, "1")]
+    [TestCase(10, 0, "10")]
+    [TestCase(0.5, 1, "0.5")]
+    [TestCase(0.75, 2, "0.75")]
+    [TestCase(0.125, 3, "0.125")]
+    [TestCase(0.0625, 4, "0.0625")]
+    [TestCase(0.03125, 5, "0.03125")]
+    [TestCase(0.015625, 6, "0.015625")]
+    [TestCase(0.0078125, 7, "0.0078125")]
+    public unsafe void FormatDoubleTest(double value, int digit, string expected)
+    {
+        // Arrange
+        byte* buffer = stackalloc byte[128];
+
+        // Act
+        int len = Utf8Formatter.Format(value, buffer, 128, CultureInfo.InvariantCulture, digit);
+        ReadOnlySpan<byte> utf8Span = new ReadOnlySpan<byte>(buffer, len);
+
+        // Assert
+        Assert.That(Encoding.UTF8.GetString(utf8Span), Is.EqualTo(expected));
+    }
+}

--- a/Hexa.NET.Utilities/Text/Utf8Formatter.cs
+++ b/Hexa.NET.Utilities/Text/Utf8Formatter.cs
@@ -326,7 +326,9 @@
                 return (int)(buffer - start);
             }
 
+            byte* beforeSeparator = buffer;
             buffer += ConvertUtf16ToUtf8(format.CurrencyDecimalSeparator, buffer, (int)(end - buffer));
+            byte* afterSeparator = buffer;
 
             digits = digits >= 0 ? digits : 7;
 
@@ -340,14 +342,14 @@
                 if (fraction < 1e-14) break;
             }
 
-            while (*(buffer - 1) == '0')
+            while (buffer != afterSeparator && *(buffer - 1) == '0')
             {
                 buffer--;
             }
 
-            while (*(buffer - 1) == '.')
+            if (buffer == afterSeparator)
             {
-                buffer--;
+                buffer = beforeSeparator;
             }
 
         end:
@@ -409,7 +411,9 @@
                 return (int)(buffer - start);
             }
 
+            byte* beforeSeparator = buffer;
             buffer += ConvertUtf16ToUtf8(format.CurrencyDecimalSeparator, buffer, (int)(end - buffer));
+            byte* afterSeparator = buffer;
 
             digits = digits >= 0 ? digits : 7;
 
@@ -423,14 +427,14 @@
                 if (fraction < 1e-14) break;
             }
 
-            while (*(buffer - 1) == '0')
+            while (buffer != afterSeparator && *(buffer - 1) == '0')
             {
                 buffer--;
             }
-            
-            while (*(buffer - 1) == '.')
+
+            if (buffer == afterSeparator)
             {
-                buffer--;
+                buffer = beforeSeparator;
             }
 
         end:

--- a/Hexa.NET.Utilities/Text/Utf8Formatter.cs
+++ b/Hexa.NET.Utilities/Text/Utf8Formatter.cs
@@ -340,7 +340,12 @@
                 if (fraction < 1e-14) break;
             }
 
-            while (*(buffer - 1) == '0' || *(buffer - 1) == '.')
+            while (*(buffer - 1) == '0')
+            {
+                buffer--;
+            }
+
+            while (*(buffer - 1) == '.')
             {
                 buffer--;
             }
@@ -418,7 +423,12 @@
                 if (fraction < 1e-14) break;
             }
 
-            while (*(buffer - 1) == '0' || *(buffer - 1) == '.')
+            while (*(buffer - 1) == '0')
+            {
+                buffer--;
+            }
+            
+            while (*(buffer - 1) == '.')
             {
                 buffer--;
             }


### PR DESCRIPTION
A fix for `Utf8Formatter` mistakenly removing zeros when formatting a floating-point whole number. 

The existing logic would format floating-point value of `10` as `"1"`, removing the zero. 
To fix this, the removal of trailing zeros and the decimal separator should be handled separately.